### PR TITLE
fix: anki subdecks are not used

### DIFF
--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/base_anki_prompt.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/base_anki_prompt.py
@@ -26,7 +26,7 @@ class AnkiCard(ABC):
 
     @property
     def deck(self) -> str:
-        deck_prefix = "#anki/deck/"
+        deck_prefix = "anki/deck/"
         deck_in_tags = (
             tag.replace(deck_prefix, "")
             for tag in self.tags

--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/base_anki_prompt.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/base_anki_prompt.py
@@ -28,7 +28,7 @@ class AnkiCard(ABC):
     def deck(self) -> str:
         deck_prefix = "anki/deck/"
         deck_in_tags = (
-            tag.replace(deck_prefix, "")
+            tag.replace(deck_prefix, "").replace("/", "::")
             for tag in self.tags
             if tag.startswith(deck_prefix)
         )

--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/test_ankiqa.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/prompt_converter/prompts/test_ankiqa.py
@@ -18,5 +18,5 @@ class FakeAnkiQA(AnkiQA):
 
 
 def test_ankiqa_deck_inference():
-    card = FakeAnkiQA(tags=["#anki/deck/Subdeck"])
+    card = FakeAnkiQA(tags=["anki/deck/Subdeck"])
     assert card.deck == "FakeBaseDeck::Subdeck"

--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
@@ -63,7 +63,9 @@ def test_ankiconnect_push_prompts():
                     QAWithoutDoc(
                         question="FakeQuestion",
                         answer="FakeAnswer",
-                        add_tags=["anki/deck/FakeSubdeck"],
+                        add_tags=[
+                            "anki/deck/FakeSubdeck/FakeSubSubdeck"
+                        ],
                     ),
                     ClozeWithoutDoc(
                         text="FakeText", add_tags=["FakeTag"]
@@ -81,7 +83,7 @@ def test_ankiconnect_push_prompts():
     )
     assert (
         import_package_command.package.decks[0].name  # type: ignore
-        == "FakeDeck::FakeSubdeck"
+        == "FakeDeck::FakeSubdeck::FakeSubSubdeck"
     )
     assert len(import_package_command.package.decks) == 2  # type: ignore
 

--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
@@ -63,7 +63,7 @@ def test_ankiconnect_push_prompts():
                     QAWithoutDoc(
                         question="FakeQuestion",
                         answer="FakeAnswer",
-                        add_tags=["FakeTag"],
+                        add_tags=["#anki/deck/FakeSubdeck"],
                     ),
                     ClozeWithoutDoc(
                         text="FakeText", add_tags=["FakeTag"]
@@ -74,6 +74,16 @@ def test_ankiconnect_push_prompts():
     )
 
     expected_commands = [(ImportPackage, 1), (UpdateModel, 2)]
+    import_package_command = next(
+        c
+        for c in gateway.executed_commands
+        if isinstance(c, ImportPackage)
+    )
+    assert (
+        import_package_command.package.decks[0].name  # type: ignore
+        == "FakeDeck::FakeSubdeck"
+    )
+
     for command in expected_commands:
         assert (
             len(

--- a/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
+++ b/personal_mnemonic_medium/domain/prompt_destination/anki_connect/test_ankiconnect_destination.py
@@ -63,7 +63,7 @@ def test_ankiconnect_push_prompts():
                     QAWithoutDoc(
                         question="FakeQuestion",
                         answer="FakeAnswer",
-                        add_tags=["#anki/deck/FakeSubdeck"],
+                        add_tags=["anki/deck/FakeSubdeck"],
                     ),
                     ClozeWithoutDoc(
                         text="FakeText", add_tags=["FakeTag"]
@@ -83,6 +83,7 @@ def test_ankiconnect_push_prompts():
         import_package_command.package.decks[0].name  # type: ignore
         == "FakeDeck::FakeSubdeck"
     )
+    assert len(import_package_command.package.decks) == 2  # type: ignore
 
     for command in expected_commands:
         assert (

--- a/personal_mnemonic_medium/domain/prompt_source/document_ingesters/document.py
+++ b/personal_mnemonic_medium/domain/prompt_source/document_ingesters/document.py
@@ -11,7 +11,7 @@ class Document:
 
     @property
     def tags(self) -> Sequence[str]:
-        return list(re.findall(r"#anki\/tag\/\S+", self.content))
+        return list(re.findall(r"#[\w\/]+", self.content))
 
     @property
     def title(self) -> str:

--- a/personal_mnemonic_medium/domain/prompt_source/document_ingesters/document.py
+++ b/personal_mnemonic_medium/domain/prompt_source/document_ingesters/document.py
@@ -11,7 +11,12 @@ class Document:
 
     @property
     def tags(self) -> Sequence[str]:
-        return list(re.findall(r"#[\w\/]+", self.content))
+        tag_strings: list[str] = list(
+            re.findall(r"#[\w\/]+", self.content)
+        )
+        return [
+            tag_string.replace("#", "") for tag_string in tag_strings
+        ]
 
     @property
     def title(self) -> str:

--- a/personal_mnemonic_medium/domain/prompt_source/document_ingesters/test_markdown_document_ingester.py
+++ b/personal_mnemonic_medium/domain/prompt_source/document_ingesters/test_markdown_document_ingester.py
@@ -7,10 +7,18 @@ def test_markdown_document_ingester(tmpdir: Path):
     ingester = MarkdownDocumentIngester(directory=Path(tmpdir))
 
     with (Path(tmpdir) / "test.md").open("w") as f:
-        f.write("# Hello World\n#anki/tag/test_tag")
+        f.write(
+            """# Hello World\n
+#anki/tag/test_tag #anki/tag/test_tag2 <!-- #comment_tag -->
+"""
+        )
 
     documents = ingester.get_documents()
     assert len(documents) == 1
     document = documents[0]
     assert document.title == "test"
-    assert document.tags == ["#anki/tag/test_tag"]
+    assert document.tags == [
+        "#anki/tag/test_tag",
+        "#anki/tag/test_tag2",
+        "#comment_tag",
+    ]

--- a/personal_mnemonic_medium/domain/prompt_source/document_ingesters/test_markdown_document_ingester.py
+++ b/personal_mnemonic_medium/domain/prompt_source/document_ingesters/test_markdown_document_ingester.py
@@ -18,7 +18,7 @@ def test_markdown_document_ingester(tmpdir: Path):
     document = documents[0]
     assert document.title == "test"
     assert document.tags == [
-        "#anki/tag/test_tag",
-        "#anki/tag/test_tag2",
-        "#comment_tag",
+        "anki/tag/test_tag",
+        "anki/tag/test_tag2",
+        "comment_tag",
     ]

--- a/personal_mnemonic_medium/domain/prompt_source/prompt_extractors/test_cloze_prompt_extractor.py
+++ b/personal_mnemonic_medium/domain/prompt_source/prompt_extractors/test_cloze_prompt_extractor.py
@@ -26,4 +26,4 @@ This is another block without any cloze prompts.
         extractor[0].text
         == r"What is the meaning of life? {{c734::42}}"
     )
-    assert extractor[0].tags == ["#anki/tag/test_tag"]
+    assert extractor[0].tags == ["anki/tag/test_tag"]

--- a/personal_mnemonic_medium/domain/prompt_source/prompt_extractors/test_qa_prompt_extractor.py
+++ b/personal_mnemonic_medium/domain/prompt_source/prompt_extractors/test_qa_prompt_extractor.py
@@ -25,5 +25,5 @@ A. 42
     prompt = extractor[0]
     assert prompt.question == "What is the meaning of life?"
     assert prompt.answer == "42"
-    assert prompt.tags == ["#anki/tag/test_tag"]
+    assert prompt.tags == ["anki/tag/test_tag"]
     assert prompt.uid == 9385242780


### PR DESCRIPTION
fix: anki subdecks are not used

Fixes #396

tests: ensure ankiconnect gets correct subdecks

fix: extract all tags from markdown documents

fix: tag strings should not contain "#"

fix: import all decks

feat: support arbitrary subdeck nesting